### PR TITLE
Fix snap so it launches correctly - fixes #2

### DIFF
--- a/retroarch.wrapper
+++ b/retroarch.wrapper
@@ -5,39 +5,6 @@
 
 set -e
 
-case "$SNAP_ARCH" in
-    "amd64") ARCH='x86_64-linux-gnu'
-    ;;
-    "i386") ARCH='i386-linux-gnu'
-    ;;
-    "armhf") ARCH='arm-linux-gnueabihf'
-    ;;
-    *)
-        echo "Unsupported architecture for this app build"
-        exit 1
-    ;;
-esac
-
-
-export LD_LIBRARY_PATH="$SNAP/usr/lib/$ARCH/dri:$SNAP/usr/lib/$ARCH/alsa-lib:$LD_LIBRARY_PATH"
-export XDG_DATA_HOME="$SNAP/usr/share"
-export FONTCONFIG_PATH="$SNAP/etc/fonts/config.d"
-export FONTCONFIG_FILE="$SNAP/etc/fonts/fonts.conf"
-export XKB_CONFIG_ROOT="$SNAP/usr/share/X11/xkb"
-
-# Mesa Libs
-export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/mesa:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/mesa-egl:$LD_LIBRARY_PATH
-
-# Tell libGL where to find the drivers
-export LIBGL_DRIVERS_PATH=$SNAP/usr/lib/$ARCH/dri
-
-# ensure that our HW/opengl libs are before the snap specific libs
-export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
-
-# Otherwise XOpenIM failed
-export XLOCALEDIR=$SNAP/usr/share/X11/locale
-
 #Notify the user that it might take a while to copy everything
 [ ! -d "$SNAP_USER_DATA/.config/retroarch" ] && notify-send "RetroArch" "Copying necessary files (this could take a minute)..." -i "$SNAP/.config/assets/xmb/monochrome/png/retroarch.png" -t 2000
 
@@ -70,5 +37,5 @@ export XLOCALEDIR=$SNAP/usr/share/X11/locale
 #If the config file doesn't exist, create it and point the browser directory outside of the snap package
 [ ! -f "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg" ] && touch "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg" && echo "rgui_browser_directory = $HOME/../../../" >> "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg"
 
-desktop-launch $SNAP/usr/local/bin/retroarch "$@"
+exec $SNAP/usr/local/bin/retroarch "$@"
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,7 +8,7 @@ grade: stable
 
 apps:
   retroarch:
-    command: usr/local/bin/retroarch.wrapper
+    command: desktop-launch $SNAP/usr/local/bin/retroarch.wrapper
     plugs: [network, network-bind, x11, opengl, home, alsa, pulseaudio, bluez, joystick, raw-usb, removable-media, wayland, unity7]
 
 parts:
@@ -41,7 +41,6 @@ parts:
      - libavcodec-ffmpeg56
      - libavformat-ffmpeg56
      - libavutil-ffmpeg54
-     - libc6
      - libdrm2
      - libegl1-mesa
      - libfreetype6
@@ -68,6 +67,12 @@ parts:
      - zlib1g
      - qt5-default
      - libqt5waylandclient5
+     - libstdc++6
+     - libgcc1
+     - liblzma5
+     - libbz2-1.0
+     - libpcre3
+     - libsystemd0
    build-packages:
      - gcc
      - make


### PR DESCRIPTION
I have tidied things up a little. Removed libc6 because you shouldn't need that in your snap, and added some other libs that were failing. I have also re-jigged the launcher so that all the environment is setup in the stock desktop launcher script which comes from desktop-qt5 which you were already using. This fixes the segfault for me on nvidia.