### PR TITLE
Fix indentation in snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -188,7 +188,7 @@ parts:
      - -configure
      - -Makefile
      - .config/shaders/shaders_glsl
-   retroarch-slang-shaders:
+  retroarch-slang-shaders:
     plugin: dump
     source: https://github.com/libretro/slang-shaders/archive/master.tar.gz
     source-type : tar


### PR DESCRIPTION
This allows it to parse as valid YAML; the previous version was causing errors on build.snapcraft.io.