### PR TITLE
[WIP] Vulkan support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# gitginore template for creating Snap packages
+# website: https://snapcraft.io/
+
+parts/
+prime/
+stage/
+*.snap
+
+# Snapcraft global state tracking data(automatically generated)
+# https://forum.snapcraft.io/t/location-to-save-global-state/768
+/snap/.snapcraft/
+
+# Source archive packed by `snapcraft cleanbuild` before pushing to the LXD container
+/*_source.tar.bz2
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,17 @@
 name: retroarch
 version: "1.7.8.3"
-summary: RetroArch
-description: RetroArch is the official reference frontend for the libretro API.
+title: RetroArch
+summary: RetroArch is the official reference frontend for the libretro API.
+description: |
+  The official reference frontend for the libretro API.
+
+  RetroArch provides a variety of advanced user-facing features and powerful configuration capabilities to programs that target the libretro API. While a majority of these programs are emulators for retro gaming consoles, various gaming engines and other multimedia applications are also represented. The programs, known as "cores", can be downloaded and updated directly from RetroArch's built-in Online Updater.
+
+  RetroArch defaults to a gamepad-friendly 10-foot/leanback interface that is perfect for use with living-room and home theater PCs, but there is also a more traditional keyboard-and-mouse interface available by pressing F5.
+
+  RetroArch is written in portable C and licensed GPLv3.
+license: GPL-3.0
+icon: snap/gui/retroarch.svg
 confinement: strict
 grade: stable
 architectures:
@@ -10,6 +20,15 @@ architectures:
 - build-on: armhf
 - build-on: arm64
 - build-on: ppc64el
+base: core
+
+layout:
+  /usr/share/vulkan:
+    symlink: $SNAP/usr/share/vulkan
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_intel.so:
+    symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_intel.so
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_radeon.so:
+    symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_radeon.so
 
 apps:
   retroarch:
@@ -29,14 +48,6 @@ apps:
       - wayland
       - unity7
       - desktop
-    passthrough:
-      layout:
-        /usr/share/vulkan:
-          symlink: $SNAP/usr/share/vulkan
-        /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_intel.so:
-          symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_intel.so
-        /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_radeon.so:
-          symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_radeon.so
 
 parts:
   retroarch:
@@ -137,10 +148,10 @@ parts:
      - qt5-default
      - libvulkan-dev
      - libsdl2-dev
-   stage:
-     - bin/
-     - lib/
-     - usr/
+  #  stage:
+  #    - bin/
+  #    - lib/
+  #    - usr/
   retroarch-wrapper:
     plugin: dump
     after: [retroarch]
@@ -234,3 +245,34 @@ parts:
     stage:
      - .config/shaders
 
+  # This part installs the qt5 dependencies and a `desktop-launch` script to initialise
+  # desktop-specific features such as fonts, themes and the XDG environment.
+  # 
+  # It is copied straight from the snapcraft desktop helpers project. Please periodically
+  # check the source for updates and copy the changes.
+  #    https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
+  # 
+  desktop-qt5:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: qt
+    plugin: make
+    make-parameters: ["FLAVOR=qt5"]
+    build-packages:
+      - build-essential
+      - qtbase5-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libqt5gui5
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5 # for loading icon themes which are svg
+      - try: [appmenu-qt5] # not available on core18
+      - locales-all
+      - xdg-user-dirs
+      - fcitx-frontend-qt5


### PR DESCRIPTION
I saw your post here: https://forum.snapcraft.io/t/do-snaps-apps-support-vulkan/10534/8?u=galgalesh

This PR gets the build working again. Retroarch starts correctly if I enable the vulkan driver and I can run super mario 64 on paraLLel so I'm guessing Vulkan works correctly?

* I moved the `layout` stuff to the "root" of the `snapcraft.yaml`. Layouts are defined for the entire snap, not for an app.
*  I commented the `stage` lines of the `retroarch` part because this triggered a build error. Note: if you don't specify `stage`; everything gets staged. Afaik, this keyword is mostly used to reduce the size of your snap by only staging stuff that is required.
* I moved to the new `base` syntax for a few reasons:
  - So we don't need `passthrough` anymore.
  - So snapcraft uses `multipass` (so I can easily and quickly develop 16.04 and 18.04 snaps on Ubuntu 19.04).
  - So it's easy to upgrade to `core18`.
* Moving to the `base` syntax also required copying the `qt-desktop` part to your `snapcraft.yaml`
* I added a `.gitignore` script so I don't accidentally commit the built snap etc.
* I added some metadata in snapcraft.yaml itself. I like it better when the metadata is in `snapcraft.yaml` so the community has a chance to propose updates using pr's.


*Note: it might also be useful to debug and test on Ubuntu instead of through github. With the switch to `base`, you can now use any Ubuntu version. Just run `snapcraft` in the root folder of this repository and it will create a VM with the correct Ubuntu version for you and do all the building inside of that VM. Moreover, it keeps the VM around so that next time you run `snapcraft`, only the steps that changed are re-run. This saves A LOT of time, each time you try something.*


