### PR TITLE
wayland: Add libdecor for CSDs on GNOME, bump SDL2 to v2.0.20 for

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,7 +39,7 @@ apps:
   retroarch:
     command: bin/desktop-launch $SNAP/usr/bin/snapcraft-preload $SNAP/usr/local/bin/retroarch.wrapper
     environment:
-      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-gl:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/xorg
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-gl:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/xorg
     plugs:
       - network
       - network-bind
@@ -105,7 +105,7 @@ parts:
 #   source-type: tar
 #   source: https://github.com/libretro/RetroArch/archive/v1.9.2.tar.gz
    source-type: git
-   after: [retroarch-wrapper]
+   after: [sdl2,libdecor,retroarch-wrapper]
    source: https://github.com/libretro/RetroArch.git
    build-environment:
      - MAKEFLAGS: HAVE_BUILTINZLIB=0 HAVE_ZLIB_COMMON=1
@@ -163,6 +163,7 @@ parts:
      - libxxf86vm1
      - zlib1g
      - qt5-default
+     - qtwayland5
      - libqt5waylandclient5
      - libstdc++6
      - libgcc1
@@ -173,7 +174,6 @@ parts:
      - libvulkan1
      - libvulkan-dev
      - mesa-vulkan-drivers
-     - libsdl2-2.0-0
      - libass9
      - libfribidi0
      - libsdl1.2debian
@@ -207,7 +207,7 @@ parts:
      - zlib1g-dev
      - qt5-default
      - libvulkan-dev
-     - libsdl2-dev
+     - libxxf86vm-dev
      - libdbus-1-dev
   retroarch-filters:
     plugin: autotools
@@ -304,7 +304,64 @@ parts:
      "*": .config/shaders/shaders_slang/
     stage:
      - .config/shaders
-
+  # Provides libdecor to implement Wayland CSD on desktop environments not using xdg-decoration (GNOME), SDL2 >= v2.0.16 adds support for libdecor
+  # SDL2 in focal repositories is at v2.0.10 so we need to include a newer version.
+  libdecor:
+    plugin: meson
+    source: https://gitlab.gnome.org/jadahl/libdecor.git
+    source-type: git
+    source-tag: "0.1.0"
+    meson-parameters:
+      - -Dprefix=/usr
+      - -Ddemo=false
+    stage-packages:
+      - libwayland-cursor0
+      - libwayland-client0
+      - libdbus-1-3
+    build-packages:
+      - wayland-protocols
+      - libwayland-dev
+      - libcairo2-dev
+      - libpango1.0-dev
+  sdl2:
+      plugin: cmake
+      after: [libdecor]
+      source: https://github.com/libsdl-org/SDL.git
+      source-tag: release-2.0.20
+      cmake-generator: Ninja
+      cmake-parameters:
+        - -DCMAKE_BUILD_TYPE=Release
+        - -DCMAKE_INSTALL_PREFIX=/usr
+        - -DCMAKE_C_COMPILER=gcc-10
+        - -DCMAKE_CXX_COMPILER=g++-10
+        - -DLIB_INSTALL_DIR:PATH=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET
+        - -DSHARE_INSTALL_PREFIX:PATH=/usr/share
+        - -DINCLUDE_INSTALL_DIR:PATH=/usr/include
+        - -DSDL_PULSEAUDIO_SHARED=ON
+        - -DSDL_DLOPEN=ON
+        - -DARTS=OFF
+        - -DESD=OFF
+        - -DNAS=OFF
+        - -DSDL_VIDEO_KMSDRM=ON
+        - -DSDL_JACK_SHARED=ON
+        - -DSDL_PIPEWIRE_SHARED=ON
+        - -DSDL_ALSA=ON
+        - -DSDL_STATIC=ON
+        - -DSDL_VIDEO_VULKAN=ON
+        - -DSDL_LIBDECOR_SHARED=ON
+        - -DSDL_VIDEO_WAYLAND=ON
+        - -DRPATH=OFF
+        - -DCLOCK_GETTIME=ON
+      override-build: |
+          snapcraftctl build
+          rsync -a --ignore-existing $SNAPCRAFT_PART_INSTALL/ /
+      build-packages:
+        - gcc-10
+        - g++-10
+        - rsync
+      stage:
+        - -usr/include
+        - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/cmake
   # This part installs the qt5 dependencies and a `desktop-launch` script to initialise
   # desktop-specific features such as fonts, themes and the XDG environment.
   # 


### PR DESCRIPTION
libdecor support. Adding qtwayland5 package to allow Qt5 interface to
launch on wayland sessions

before:
![retroarch-no-libdecor](https://user-images.githubusercontent.com/24817147/151703223-686bbe62-504f-496d-9792-05e73895b21d.png)

after:
![retroarch-libdecor](https://user-images.githubusercontent.com/24817147/151703232-09c5972a-b6ca-4f11-b572-f5e3bc780232.png)

Without libdecor:
* window lacks a titlebar and window controls
* no drop shadows to distinguish against other windows when stacked on top of other application windows
* unable to move the window.
