### PR TITLE
snap: migrate to `base: core22`

### DIFF
--- a/retroarch.wrapper
+++ b/retroarch.wrapper
@@ -1,12 +1,22 @@
 #!/bin/sh
 
-#Notify user that we're working so they don't think anything is broken
-[ ! -d "$SNAP_USER_DATA/.config/retroarch" ] && notify-send "RetroArch" "Preparing the environment..." -i "$SNAP/.config/assets/xmb/monochrome/png/retroarch.png" -t 2000
-
 set -e
 
+MAINCONFIG="$SNAP_USER_DATA/.config/retroarch/retroarch.cfg"
+
+_notify() {
+   local msg=$1
+   local timeout=2000
+   local icon="$SNAP/.config/assets/xmb/monochrome/png/retroarch.png"
+
+   notify-send "RetroArch" "${msg}" -i ${icon} -t $timeout
+}
+
+#Notify user that we're working so they don't think anything is broken
+[ ! -d "$SNAP_USER_DATA/.config/retroarch" ] && _notify "Preparing the environment..."
+
 #Notify the user that it might take a while to copy everything
-[ ! -d "$SNAP_USER_DATA/.config/retroarch" ] && notify-send "RetroArch" "Copying necessary files (this could take a minute)..." -i "$SNAP/.config/assets/xmb/monochrome/png/retroarch.png" -t 2000
+[ ! -d "$SNAP_USER_DATA/.config/retroarch" ] && _notify "Copying necessary files (this could take a minute)..."
 
 #Create RetroArch user configuration directory if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config" ] && mkdir "$SNAP_USER_DATA/.config"
@@ -15,53 +25,30 @@ set -e
 #Copy assets if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config/retroarch/assets" ] && cp -R "$SNAP/.config/assets" "$SNAP_USER_DATA/.config/retroarch"
 
-#Copy joypad autoconfig files if doesn't exist 
+#Copy joypad autoconfig files if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config/retroarch/autoconfig" ] && cp -R "$SNAP/.config/autoconfig" "$SNAP_USER_DATA/.config/retroarch"
 
-#Copy cheats files if doesn't exist 
+#Copy cheats files if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config/retroarch/cheats" ] && cp -R "$SNAP/.config/cheats" "$SNAP_USER_DATA/.config/retroarch"
 
-#Copy database files if doesn't exist 
+#Copy database files if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config/retroarch/database" ] && cp -R "$SNAP/.config/database" "$SNAP_USER_DATA/.config/retroarch"
 
-#Copy info files if doesn't exist 
+#Copy info files if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config/retroarch/cores" ] && cp -R "$SNAP/.config/cores" "$SNAP_USER_DATA/.config/retroarch"
 
-#Copy overlay if doesn't exist 
+#Copy overlay if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config/retroarch/overlay" ] && cp -R "$SNAP/.config/overlay" "$SNAP_USER_DATA/.config/retroarch"
 
-#Copy shaders if doesn't exist 
+#Copy shaders if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config/retroarch/shaders" ] && cp -R "$SNAP/.config/shaders" "$SNAP_USER_DATA/.config/retroarch"
 
-#Copy filters if doesn't exist 
+#Copy filters if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config/retroarch/filters" ] && cp -R "$SNAP/.config/filters" "$SNAP_USER_DATA/.config/retroarch"
 
-[ ! -f "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg" ] && notify-send "RetroArch" "Done!" -i "$SNAP/.config/assets/xmb/monochrome/png/retroarch.png" -t 2000
+[ ! -f "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg" ] && _notify "Done!"
 
 #If the config file doesn't exist, create it and point the browser directory outside of the snap package
-[ ! -f "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg" ] && touch "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg" && echo "rgui_browser_directory = $SNAP_REAL_HOME" >> "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg" && echo "input_joypad_driver = sdl2" >> "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg"
+[ ! -f "$MAINCONFIG" ] && echo "rgui_browser_directory = $SNAP_REAL_HOME" >> "$MAINCONFIG" && echo "input_joypad_driver = sdl2" >> "$MAINCONFIG"
 
-# As discussed here:
-#  - https://forum.snapcraft.io/t/egl-using-snaps-on-impish-seem-to-be-broken-when-using-the-nvidia-proprietary-driver/25715
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH#$SNAP_LIBRARY_PATH:}"
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${SNAP_LIBRARY_PATH}"
-
-export SNAPCRAFT_PRELOAD=$SNAP
-export LD_PRELOAD=$SNAP/usr/lib/libsnapcraft-preload.so
-
-# As discussed here:
-#  - https://forum.snapcraft.io/t/correct-way-to-do-nvidia-vulkan/20361/2
-# Export the Vulkan ICD filename paths to fix Vulkan on Nvidia proprietary driver
-#  - There is no Intel ICD for ARM
-if [ "$SNAP_ARCH" = "amd64" ]; then
-  export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon.x86_64.json:$SNAP/usr/share/vulkan/icd.d/intel_icd.x86_64.json"
-elif [ "$SNAP_ARCH" = "i386" ]; then
-  export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon.i686.json:$SNAP/usr/share/vulkan/icd.d/intel_icd.i686.json"
-elif [ "$SNAP_ARCH" = "armhf" ]; then
-  export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon.armv7l.json"
-elif [ "$SNAP_ARCH" = "arm64" ]; then
-  export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon.aarch64.json"
-fi
-
-exec $SNAP/usr/local/bin/retroarch "$@"
-
+exec "$@"

--- a/retroarch.wrapper
+++ b/retroarch.wrapper
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
 MAINCONFIG="$SNAP_USER_DATA/.config/retroarch/retroarch.cfg"
+FILESETS=('assets' 'autoconfig' 'cheats' 'cores' 'database' 'filters' 'overlay' 'shaders')
 
 _notify() {
    local msg=$1
@@ -22,29 +23,14 @@ _notify() {
 [ ! -d "$SNAP_USER_DATA/.config" ] && mkdir "$SNAP_USER_DATA/.config"
 [ ! -d "$SNAP_USER_DATA/.config/retroarch" ] && mkdir "$SNAP_USER_DATA/.config/retroarch"
 
-#Copy assets if doesn't exist
-[ ! -d "$SNAP_USER_DATA/.config/retroarch/assets" ] && cp -R "$SNAP/.config/assets" "$SNAP_USER_DATA/.config/retroarch"
-
-#Copy joypad autoconfig files if doesn't exist
-[ ! -d "$SNAP_USER_DATA/.config/retroarch/autoconfig" ] && cp -R "$SNAP/.config/autoconfig" "$SNAP_USER_DATA/.config/retroarch"
-
-#Copy cheats files if doesn't exist
-[ ! -d "$SNAP_USER_DATA/.config/retroarch/cheats" ] && cp -R "$SNAP/.config/cheats" "$SNAP_USER_DATA/.config/retroarch"
-
-#Copy database files if doesn't exist
-[ ! -d "$SNAP_USER_DATA/.config/retroarch/database" ] && cp -R "$SNAP/.config/database" "$SNAP_USER_DATA/.config/retroarch"
-
-#Copy info files if doesn't exist
-[ ! -d "$SNAP_USER_DATA/.config/retroarch/cores" ] && cp -R "$SNAP/.config/cores" "$SNAP_USER_DATA/.config/retroarch"
-
-#Copy overlay if doesn't exist
-[ ! -d "$SNAP_USER_DATA/.config/retroarch/overlay" ] && cp -R "$SNAP/.config/overlay" "$SNAP_USER_DATA/.config/retroarch"
-
-#Copy shaders if doesn't exist
-[ ! -d "$SNAP_USER_DATA/.config/retroarch/shaders" ] && cp -R "$SNAP/.config/shaders" "$SNAP_USER_DATA/.config/retroarch"
-
-#Copy filters if doesn't exist
-[ ! -d "$SNAP_USER_DATA/.config/retroarch/filters" ] && cp -R "$SNAP/.config/filters" "$SNAP_USER_DATA/.config/retroarch"
+#Copy filesets if doesn't exist
+for fileset in ${FILESETS[@]};
+do
+   if [ ! -d "$SNAP_USER_DATA/.config/retroarch/$fileset" ];
+   then
+      cp -R "$SNAP/.config/$fileset" "$SNAP_USER_DATA/.config/retroarch"
+   fi
+done
 
 [ ! -f "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg" ] && _notify "Done!"
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -15,31 +15,37 @@ icon: snap/gui/retroarch.svg
 confinement: strict
 grade: stable
 architectures:
-- build-on: amd64
-  run-on: amd64
-- build-on: armhf
-  run-on: armhf
-- build-on: arm64
-  run-on: arm64
-- build-on: ppc64el
-  run-on: ppc64el
-base: core20
+- build-on: [amd64]
+  build-for: [amd64]
+- build-on: [armhf]
+  build-for: [armhf]
+- build-on: [arm64]
+  build-for: [arm64]
+- build-on: [ppc64el]
+  build-for: [ppc64el]
+base: core22
+
+plugs:
+  graphics-core22:
+    interface: content
+    target: $SNAP/graphics
+    default-provider: mesa-core22
 
 layout:
-  /usr/share/vulkan:
-    symlink: $SNAP/usr/share/vulkan
-  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_intel.so:
-    symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_intel.so
-  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_radeon.so:
-    symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvulkan_radeon.so
   /usr/share/libdrm:
-    bind: $SNAP/usr/share/libdrm
+    bind: $SNAP/graphics/libdrm
+  /usr/share/drirc.d:
+    symlink: $SNAP/graphics/drirc.d
 
 apps:
   retroarch:
-    command: bin/desktop-launch $SNAP/usr/bin/snapcraft-preload $SNAP/usr/local/bin/retroarch.wrapper
-    environment:
-      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-gl:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/xorg
+    extensions:
+      - kde-neon
+    command-chain:
+    - bin/graphics-core22-wrapper
+    - usr/bin/snapcraft-preload
+    - usr/local/bin/retroarch.wrapper
+    command: usr/local/bin/retroarch
     plugs:
       - network
       - network-bind
@@ -63,7 +69,7 @@ apps:
 #  daemon:
 #    command: $SNAP/usr/bin/snapcraft-preload $SNAP/usr/local/bin/daemon-start.sh $SNAP/usr/local/bin/retroarch.wrapper
 #    environment:
-#      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-gl:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/xorg
+#      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/dri:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/mesa-gl:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/xorg
 #    daemon: simple
 #    restart-condition: always
 #    plugs:
@@ -96,7 +102,7 @@ parts:
         - lib32stdc++6
   retroarch-wrapper:
     plugin: dump
-    after: [desktop-qt5]
+    after: [snapcraft-preload]
     source: .
     organize:
      retroarch.wrapper: usr/local/bin/retroarch.wrapper
@@ -110,14 +116,14 @@ parts:
 #   source: https://github.com/libretro/RetroArch/archive/v1.13.0.tar.gz
    source-type: git
    source: https://github.com/libretro/RetroArch.git
-   after: [sdl2,libdecor,retroarch-wrapper]
+   after: [retroarch-wrapper]
    build-environment:
      - MAKEFLAGS: HAVE_BUILTINZLIB=0 HAVE_ZLIB_COMMON=1
-   autotools-configure-parameters:  
+   autotools-configure-parameters:
      - --enable-kms
      - --enable-xvideo
      - --enable-ffmpeg
-     - --enable-ssa 
+     - --enable-ssa
      - --disable-coreaudio
      - --enable-jack
      - --enable-pulse
@@ -140,25 +146,15 @@ parts:
      - libavcodec58
      - libavformat58
      - libavutil56
-     - libdrm2
-     - libegl1-mesa
      - libfreetype6
      - libgbm1
-     - libgl1-mesa-dri
-     - libgl1-mesa-glx
-     - libgles2-mesa
      - libjack-jackd2-0
      - libminizip1
      - libopenal1
-     - libpulse0
      - libswresample3
      - libswscale5
      - libudev1
      - libusb-1.0-0
-     - libwayland-client0
-     - libwayland-egl1-mesa
-     - libx11-6
-     - libx11-dev
      - libxrandr-dev
      - libxext6
      - libxinerama1
@@ -166,18 +162,12 @@ parts:
      - libxv1
      - libxxf86vm1
      - zlib1g
-     - qt5-default
-     - qtwayland5
-     - libqt5waylandclient5
      - libstdc++6
      - libgcc1
      - liblzma5
      - libbz2-1.0
      - libpcre3
      - libsystemd0
-     - libvulkan1
-     - libvulkan-dev
-     - mesa-vulkan-drivers
      - libass9
      - libfribidi0
      - libsdl1.2debian
@@ -185,6 +175,9 @@ parts:
      - libbluetooth3
      - libxi6
      - libaio1
+#     - libdecor-0-0
+     - libdecor-0-plugin-1-cairo
+     - libsdl2-2.0-0
    build-packages:
      - gcc
      - make
@@ -195,7 +188,7 @@ parts:
      - libavformat-dev
      - libdrm-dev
      - libegl1-mesa-dev
-     - libfreetype6-dev 
+     - libfreetype6-dev
      - libgbm-dev
      - libgl1-mesa-dev
      - libjack-jackd2-dev
@@ -209,21 +202,24 @@ parts:
      - mesa-common-dev
      - xserver-xorg-input-all
      - zlib1g-dev
-     - qt5-default
+     - qtbase5-dev
+     - qt5-qmake
      - libvulkan-dev
      - libxxf86vm-dev
      - libdbus-1-dev
+     - libdecor-0-dev
+     - libsdl2-dev
    override-build: |
-     snapcraftctl build
-     ln -sf ../usr/lib/libsnapcraft-preload.so $SNAPCRAFT_PART_INSTALL/lib/libsnapcraft-preload.so    
+     craftctl default
+     ln -sf ../usr/lib/libsnapcraft-preload.so $CRAFT_PART_INSTALL/lib/libsnapcraft-preload.so
   retroarch-filters:
     plugin: autotools
     after: [retroarch]
     source: https://github.com/libretro/RetroArch.git
     source-type: git
     override-build: |
-     cd libretro-common/audio/dsp_filters/ && ./configure && make && make install DESTDIR=$SNAPCRAFT_PART_INSTALL/.config/filters/audio INSTALLDIR=
-     cd ../../../gfx/video_filters/ && ./configure && make && make install DESTDIR=$SNAPCRAFT_PART_INSTALL/.config/filters/video INSTALLDIR=
+     cd libretro-common/audio/dsp_filters/ && ./configure && make && make install DESTDIR=$CRAFT_PART_INSTALL/.config/filters/audio INSTALLDIR=
+     cd ../../../gfx/video_filters/ && ./configure && make && make install DESTDIR=$CRAFT_PART_INSTALL/.config/filters/video INSTALLDIR=
     stage:
       - .config/filters/video
       - .config/filters/audio
@@ -239,14 +235,28 @@ parts:
      ozone: .config/assets/ozone/
      sounds: .config/assets/sounds/
      menu_widgets: .config/assets/menu_widgets/
-    filesets:
-      assets: [.config/assets/menu_widgets/*, .config/assets/sounds/*, .config/assets/ozone/*, .config/assets/rgui/*, .config/assets/xmb/*, -.config/assets/xmb/*/src, .config/assets/glui/*.png, .config/assets/glui/*.ttf]
+#    filesets:
+#      assets: [.config/assets/menu_widgets/*, .config/assets/sounds/*, .config/assets/ozone/*, .config/assets/rgui/*, .config/assets/xmb/*, -.config/assets/xmb/*/src, .config/assets/glui/*.png, .config/assets/glui/*.ttf]
     stage:
     - -configure
     - -Makefile
-    - $assets
+    - .config/assets/menu_widgets/*
+    - .config/assets/sounds/*
+    - .config/assets/ozone/*
+    - .config/assets/rgui/*
+    - .config/assets/xmb/*
+    - -.config/assets/xmb/*/src
+    - .config/assets/glui/*.png
+    - .config/assets/glui/*.ttf]
     prime:
-    - $assets
+    - .config/assets/menu_widgets/*
+    - .config/assets/sounds/*
+    - .config/assets/ozone/*
+    - .config/assets/rgui/*
+    - .config/assets/xmb/*
+    - -.config/assets/xmb/*/src
+    - .config/assets/glui/*.png
+    - .config/assets/glui/*.ttf]
   retroarch-autoconfig:
     plugin: dump
     after: [retroarch-assets]
@@ -257,18 +267,24 @@ parts:
       linuxraw: .config/autoconfig/linuxraw/
       hid: .config/autoconfig/hid/
       x: .config/autoconfig/x/
-    filesets:
-      autoconfig: [ .config/autoconfig/udev, .config/autoconfig/linuxraw, .config/autoconfig/hid, .config/autoconfig/x]
+#    filesets:
+#      autoconfig: [ .config/autoconfig/udev, .config/autoconfig/linuxraw, .config/autoconfig/hid, .config/autoconfig/x]
     stage:
-    - $autoconfig
+    - .config/autoconfig/udev
+    - .config/autoconfig/linuxraw
+    - .config/autoconfig/hid
+    - .config/autoconfig/x
     prime:
-    - $autoconfig
+    - .config/autoconfig/udev
+    - .config/autoconfig/linuxraw
+    - .config/autoconfig/hid
+    - .config/autoconfig/x
   retroarch-database:
     plugin: dump
     after: [retroarch-autoconfig]
     source: https://github.com/libretro/libretro-database/archive/master.tar.gz
     source-type : tar
-    organize: 
+    organize:
      rdb: .config/database/rdb/
      cursors: .config/database/cursors/
      cht: .config/cheats/
@@ -311,94 +327,12 @@ parts:
      "*": .config/shaders/shaders_slang/
     stage:
      - .config/shaders
-  # Provides libdecor to implement Wayland CSD on desktop environments not using xdg-decoration (GNOME), SDL2 >= v2.0.16 adds support for libdecor
-  # SDL2 in focal repositories is at v2.0.10 so we need to include a newer version.
-  libdecor:
-    plugin: meson
-    source: https://gitlab.gnome.org/jadahl/libdecor.git
-    source-type: git
-    source-tag: "0.1.0"
-    meson-parameters:
-      - -Dprefix=/usr
-      - -Ddemo=false
-    stage-packages:
-      - libwayland-cursor0
-      - libwayland-client0
-      - libdbus-1-3
-    build-packages:
-      - wayland-protocols
-      - libwayland-dev
-      - libcairo2-dev
-      - libpango1.0-dev
-  sdl2:
-      plugin: cmake
-      after: [libdecor]
-      source: https://github.com/libsdl-org/SDL.git
-      source-tag: release-2.0.20
-      cmake-generator: Ninja
-      cmake-parameters:
-        - -DCMAKE_BUILD_TYPE=Release
-        - -DCMAKE_INSTALL_PREFIX=/usr
-        - -DCMAKE_C_COMPILER=gcc-10
-        - -DCMAKE_CXX_COMPILER=g++-10
-        - -DLIB_INSTALL_DIR:PATH=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET
-        - -DSHARE_INSTALL_PREFIX:PATH=/usr/share
-        - -DINCLUDE_INSTALL_DIR:PATH=/usr/include
-        - -DSDL_PULSEAUDIO_SHARED=ON
-        - -DSDL_DLOPEN=ON
-        - -DARTS=OFF
-        - -DESD=OFF
-        - -DNAS=OFF
-        - -DSDL_VIDEO_KMSDRM=ON
-        - -DSDL_JACK_SHARED=ON
-        - -DSDL_PIPEWIRE_SHARED=ON
-        - -DSDL_ALSA=ON
-        - -DSDL_STATIC=ON
-        - -DSDL_VIDEO_VULKAN=ON
-        - -DSDL_LIBDECOR_SHARED=ON
-        - -DSDL_VIDEO_WAYLAND=ON
-        - -DRPATH=OFF
-        - -DCLOCK_GETTIME=ON
-      override-build: |
-          snapcraftctl build
-          rsync -a --ignore-existing $SNAPCRAFT_PART_INSTALL/ /
-      build-packages:
-        - gcc-10
-        - g++-10
-        - rsync
-      stage:
-        - -usr/include
-        - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/cmake
-  # This part installs the qt5 dependencies and a `desktop-launch` script to initialise
-  # desktop-specific features such as fonts, themes and the XDG environment.
-  # 
-  # It is copied straight from the snapcraft desktop helpers project. Please periodically
-  # check the source for updates and copy the changes.
-  #    https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
-  # 
-  desktop-qt5:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: qt
-    plugin: make
-    after: [snapcraft-preload]
-    make-parameters: ["FLAVOR=qt5"]
-    build-packages:
-      - build-essential
-      - qtbase5-dev
-      - dpkg-dev
-    stage-packages:
-      - libxkbcommon0
-      - ttf-ubuntu-font-family
-      - dmz-cursor-theme
-      - light-themes
-      - adwaita-icon-theme
-      - gnome-themes-standard
-      - shared-mime-info
-      - libqt5gui5
-      - libgtk2.0-0
-      - libgdk-pixbuf2.0-0
-      - libqt5svg5 # for loading icon themes which are svg
-      - try: [appmenu-qt5] # not available on core18
-      - locales-all
-      - xdg-user-dirs
-      - fcitx-frontend-qt5
+  graphics-core22:
+    after: [retroarch]
+    source: https://github.com/canonical/gpu-snap.git
+    plugin: dump
+    override-prime: |
+      craftctl default
+      ${CRAFT_PART_SRC}/bin/graphics-core22-cleanup mesa-core22 nvidia-core22
+    prime:
+    - bin/graphics-core22-wrapper


### PR DESCRIPTION
* Migration according https://snapcraft.io/docs/migrate-core22 . Cleanup.
* Using [the graphics-core22 Snap interface](https://mir-server.io/docs/the-graphics-core22-snap-interface). This should fix https://github.com/libretro/RetroArch/issues/15843
* Using [the kde-neon extension](https://snapcraft.io/docs/kde-neon-extension) instead of desktop helper

Tested on vm's:
- ubuntu 20.04, amd64, llvmpipe, X11
- debian 12, amd64, llvmpipe, X11