### PR TITLE
Revert desktop-qt5 part

### DIFF
--- a/retroarch.wrapper
+++ b/retroarch.wrapper
@@ -13,17 +13,17 @@ _notify() {
    notify-send "RetroArch" "${msg}" -i ${icon} -t $timeout
 }
 
-#Notify user that we're working so they don't think anything is broken
+# Notify user that we're working so they don't think anything is broken
 [ ! -d "$SNAP_USER_DATA/.config/retroarch" ] && _notify "Preparing the environment..."
 
-#Notify the user that it might take a while to copy everything
+# Notify the user that it might take a while to copy everything
 [ ! -d "$SNAP_USER_DATA/.config/retroarch" ] && _notify "Copying necessary files (this could take a minute)..."
 
-#Create RetroArch user configuration directory if doesn't exist
+# Create RetroArch user configuration directory if doesn't exist
 [ ! -d "$SNAP_USER_DATA/.config" ] && mkdir "$SNAP_USER_DATA/.config"
 [ ! -d "$SNAP_USER_DATA/.config/retroarch" ] && mkdir "$SNAP_USER_DATA/.config/retroarch"
 
-#Copy filesets if doesn't exist
+# Copy filesets if doesn't exist
 for fileset in ${FILESETS[@]};
 do
    if [ ! -d "$SNAP_USER_DATA/.config/retroarch/$fileset" ];
@@ -34,7 +34,17 @@ done
 
 [ ! -f "$SNAP_USER_DATA/.config/retroarch/retroarch.cfg" ] && _notify "Done!"
 
-#If the config file doesn't exist, create it and point the browser directory outside of the snap package
+# If the config file doesn't exist, create it and point the browser directory outside of the snap package
 [ ! -f "$MAINCONFIG" ] && echo "rgui_browser_directory = $SNAP_REAL_HOME" >> "$MAINCONFIG" && echo "input_joypad_driver = sdl2" >> "$MAINCONFIG"
+
+# Make PulseAudio socket available inside the snap-specific $XDG_RUNTIME_DIR
+if [ -n "$XDG_RUNTIME_DIR" ] && [ -S "$XDG_RUNTIME_DIR/../pulse/native" ];
+then
+   export PULSE_SERVER="unix:$XDG_RUNTIME_DIR/../pulse/native"
+fi
+
+# Override to layout for X11
+export QTCOMPOSE=/usr/share/X11/locale
+export XLOCALEDIR=/usr/share/X11/locale
 
 exec "$@"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -36,16 +36,23 @@ layout:
     bind: $SNAP/graphics/libdrm
   /usr/share/drirc.d:
     symlink: $SNAP/graphics/drirc.d
+  /usr/share/X11/XErrorDB:
+    symlink: $SNAP/graphics/X11/XErrorDB
+  /usr/share/X11/locale:
+    symlink: $SNAP/graphics/X11/locale
 
 apps:
   retroarch:
-    extensions:
-      - kde-neon
+    #extensions:
+    #  - kde-neon
     command-chain:
+    - bin/desktop-launch
     - bin/graphics-core22-wrapper
     - usr/bin/snapcraft-preload
     - usr/local/bin/retroarch.wrapper
     command: usr/local/bin/retroarch
+    environment:
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/graphics/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
     plugs:
       - network
       - network-bind
@@ -102,7 +109,7 @@ parts:
         - lib32stdc++6
   retroarch-wrapper:
     plugin: dump
-    after: [snapcraft-preload]
+    after: [desktop-qt5]
     source: .
     organize:
      retroarch.wrapper: usr/local/bin/retroarch.wrapper
@@ -151,6 +158,7 @@ parts:
      - libjack-jackd2-0
      - libminizip1
      - libopenal1
+     - libpulse0
      - libswresample3
      - libswscale5
      - libudev1
@@ -160,8 +168,10 @@ parts:
      - libxinerama1
      - libxkbcommon0
      - libxv1
-     - libxxf86vm1
      - zlib1g
+     - qtbase5-dev
+     - qtwayland5
+     - libqt5waylandclient5
      - libstdc++6
      - libgcc1
      - liblzma5
@@ -327,6 +337,38 @@ parts:
      "*": .config/shaders/shaders_slang/
     stage:
      - .config/shaders
+  # This part installs the qt5 dependencies and a `desktop-launch` script to initialise
+  # desktop-specific features such as fonts, themes and the XDG environment.
+  #
+  # It is copied straight from the snapcraft desktop helpers project. Please periodically
+  # check the source for updates and copy the changes.
+  #    https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
+  #
+  desktop-qt5:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: qt
+    plugin: make
+    after: [snapcraft-preload]
+    make-parameters: ["FLAVOR=qt5"]
+    build-packages:
+      - build-essential
+      - qtbase5-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - fonts-ubuntu
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libqt5gui5
+      - libgtk2.0-0
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5  # for loading icon themes which are svg
+      - locales-all
+      - xdg-user-dirs
+      - fcitx-frontend-qt5
   graphics-core22:
     after: [retroarch]
     source: https://github.com/canonical/gpu-snap.git


### PR DESCRIPTION
Revert legacy `desktop-helpers` for support all architectures.
Fix pulseaudio environment for apps on core22 without extensions.