### PR TITLE
Autodetect version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: retroarch
-version: "1.19.1"
+adopt-info: retroarch  # define the version at `retroarch` part
 title: RetroArch
 summary: RetroArch is the official reference frontend for the libretro API.
 description: |
@@ -115,8 +115,6 @@ parts:
       - inotify-tools
   retroarch:
    plugin: autotools
-#   source-type: tar
-#   source: https://github.com/libretro/RetroArch/archive/v1.13.0.tar.gz
    source-type: git
    source: https://github.com/libretro/RetroArch.git
    after: [retroarch-wrapper]
@@ -215,6 +213,18 @@ parts:
      - libdbus-1-dev
      - libdecor-0-dev
      - libsdl2-dev
+   override-pull: |
+     craftctl default
+     tag=$(git describe --tags --abbrev=0)
+     count=$(git rev-list $tag.. --count)
+     if [ "$count" = 0 ];
+     then
+       version=${tag:1}
+     else
+       hash=$(git rev-parse --short=7 HEAD)
+       version=${tag:1}+git${count}.${hash}
+     fi
+     craftctl set version=$version
   retroarch-filters:
     plugin: autotools
     after: [retroarch]


### PR DESCRIPTION
Snapcraft will define the version based on the last git-commit. If the last commit points to the tag, then the version will be set according to the release version, otherwise will be added the number of commits from the last tag and the hash of the commit from which the application was compiled. For example:

Build from https://github.com/libretro/RetroArch/commit/b1aa7522fd3f485b2697286472e802da86244bea will have version `1.19.1+git387.b1aa752`
Build from https://github.com/libretro/RetroArch/commit/06fa5325f8b3cd42e6fba3d57835d5924c9ea2e7 will have version `1.18.0`