### PR TITLE
Turn `--enable-qt` back on 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -135,7 +135,7 @@ parts:
      - --disable-vg
      - --disable-v4l2
      - --disable-xinerama
-#     - --enable-qt
+     - --enable-qt
      - --enable-vulkan
      - --enable-discord
      - --enable-dbus


### PR DESCRIPTION
Already fixed in https://github.com/libretro/RetroArch/pull/17346