### PR TITLE
[wait to merge] Add PipeWire support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,7 @@ apps:
       - hardware-observe
       - mount-observe
       - camera
+      - pipewire
   daemon:
     command-chain:
     - bin/daemon-start.sh
@@ -120,7 +121,7 @@ parts:
       - libfreetype6
       - libgbm1
       - libjack-jackd2-0
-      #- libpipewire-0.3-dev
+      - libpipewire-0.3-dev
       - libminizip1t64
       - libopenal1
       - libpulse0


### PR DESCRIPTION
This has already been added to the [documentation](https://snapcraft.io/docs/supported-interfaces) https://forum.snapcraft.io/t/the-pipewire-interface/45650 , but still unavailable in snapd stable release. Judging by the changes in the code, pipewire interface will soon become available without extra compilation parts.